### PR TITLE
fix(typo): change self.nodes to self._nodes

### DIFF
--- a/villas/controller/components/managers/villas_node.py
+++ b/villas/controller/components/managers/villas_node.py
@@ -90,7 +90,7 @@ class VILLASnodeManager(Manager):
         self.change_state('idle')
 
         # Once the gateway shutsdown, all the gateway nodes are also shutdown
-        for node in self.nodes:
+        for node in self._nodes:
             node.change_state('shutdown')
 
     def pause(self, payload):
@@ -99,7 +99,7 @@ class VILLASnodeManager(Manager):
         self.change_state('paused')
 
         # Once the gateway shutsdown, all the gateway nodes are also shutdown
-        for node in self.nodes:
+        for node in self._nodes:
             node.change_state('paused')
 
     def resume(self, payload):


### PR DESCRIPTION
## Recreate Error

1. Run `rabbitmq`
2. Run `villas node`

Example config file `example.json` for villas-controller:

```json
{
  "broker": {
    "url": "amqp://guest:guest@localhost/%2F"
  },
  "components": [
    {
      "category": "manager",
      "type": "villas-node"
    }
  ]
}
```

3. Run `villas-controller -c example.json -d DEBUG daemon`

Example Python script `tx.py` to send commands to the VILLASnodeManager instance via RabbitMQ.

```py
import argparse
import kombu

parser = argparse.ArgumentParser()
parser.add_argument("action", type=str)
args = parser.parse_args()

connection = kombu.Connection("amqp://guest:guest@localhost/%2F")
exchange = kombu.Exchange(name="villas", type="headers", durable=True)

producer = connection.Producer()
producer.publish({"action": args.action}, exchange=exchange, headers={"type": "villas-node"})
```

4. Run `python tx.py start`
5. Run `python tx.py stop`

Following Error message should appear:

```sh
AttributeError: 'VILLASnodeManager' object has no attribute 'nodes'. Did you mean: '_nodes'?
```

The same typo appears also in the `pause` method. In step 5 run `python tx.py pause`.